### PR TITLE
Using Docker to add CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,71 @@
+# Copyright 2018 Xaptum, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License
+
+sudo: required
+
+language: cpp
+
+services:
+  - docker
+
+jobs:
+  include:
+
+# Release build, gcc
+  - env: TYPE=RELEASE
+    before_script:
+      - docker pull xaptum/xtt-cpp:0.1.0
+
+    script:
+      - docker run -v $(pwd):/xttcpp/ -d -t --name xttcpp xaptum/xtt-cpp:0.1.0
+      - docker exec -it xttcpp bash -c "cd xttcpp && mkdir -p build"
+      - docker exec -it xttcpp bash -c "cd xttcpp/build && cmake .. -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++"
+      - docker exec -it xttcpp bash -c "cd xttcpp/build && make"
+      - docker exec -it xttcpp bash -c "cd xttcpp/build && ctest -VV"
+
+# Debug build
+  - env: TYPE=DEBUG
+    before_script:
+      - docker pull xaptum/xtt-cpp:0.1.0
+
+    script:
+      - docker run -v $(pwd):/xttcpp/ -d -t --name xttcpp xaptum/xtt-cpp:0.1.0
+      - docker exec -it xttcpp bash -c "cd xttcpp && mkdir -p build"
+      - docker exec -it xttcpp bash -c "cd xttcpp/build && cmake .. -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++"
+      - docker exec -it xttcpp bash -c "cd xttcpp/build && make"
+      - docker exec -it xttcpp bash -c "cd xttcpp/build && ctest -VV"
+
+# Release build, clang
+  - env: TYPE=RELEASE-WITH-CLANG
+    before_script:
+    - docker pull xaptum/xtt-cpp:0.1.0
+
+    script:
+    - docker run -v $(pwd):/xttcpp/ -d -t --name xttcpp xaptum/xtt-cpp:0.1.0
+    - docker exec -it xttcpp bash -c "cd xttcpp && mkdir -p build"
+    - docker exec -it xttcpp bash -c "cd xttcpp/build && cmake .. -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++"
+    - docker exec -it xttcpp bash -c "cd xttcpp/build && make"
+    - docker exec -it xttcpp bash -c "cd xttcpp/build && ctest -VV"
+
+# Sanitizers
+  - env: TYPE=SANITIZE
+    before_script:
+        - docker pull xaptum/xtt-cpp:0.1.0
+
+    script:
+    - docker run -v $(pwd):/xttcpp/ -d -t --name xttcpp xaptum/xtt-cpp:0.1.0
+    - docker exec -it xttcpp bash -c "cd xttcpp && mkdir -p build"
+    - docker exec -it xttcpp bash -c "cd xttcpp/build && cmake .. -DCMAKE_BUILD_TYPE=RelWithSanitize -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++"
+    - docker exec -it xttcpp bash -c "cd xttcpp/build && make"
+    - docker exec -it xttcpp bash -c "cd xttcpp/build && ctest -VV"

--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:xenial
+
+RUN apt-get -qq update \
+    && apt-get -qq install -y --no-install-recommends \
+       build-essential \
+       wget \
+       clang \
+       g++ \
+       ca-certificates \
+       && rm -rf /var/lib/apt/lists/* \
+       && wget -q https://cmake.org/files/v3.11/cmake-3.11.4-Linux-x86_64.tar.gz \
+       && tar -xzf cmake-3.11.4-Linux-x86_64.tar.gz \
+       && cp -fR cmake-3.11.4-Linux-x86_64/* /usr \
+       && rm -rf cmake-3.11.4-Linux-x86_64 \
+       && rm cmake-3.11.4-Linux-x86_64.tar.gz
+
+#INSTALLS BOOST
+RUN wget http://downloads.sourceforge.net/project/boost/boost/1.66.0/boost_1_66_0.tar.gz \
+  && tar xfz boost_1_66_0.tar.gz \
+  && rm boost_1_66_0.tar.gz \
+  && cd boost_1_66_0 \
+  && ./bootstrap.sh --prefix=/usr/local --with-libraries=system,thread \
+  && ./b2 install \
+  && cd ..
+
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys c615bfaa7fe1b4ca
+RUN echo "deb http://dl.bintray.com/xaptum/deb stretch main" > /etc/apt/sources.list.d/xaptum.list
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
+RUN apt-get install libsodium18
+RUN apt-get install libsodium-dev
+RUN apt-get install libamcl4
+RUN apt-get install libamcl-dev
+RUN apt-get install libxaptum-tpm0
+RUN apt-get install libxaptum-tpm-dev
+RUN apt-get install libecdaa0
+RUN apt-get install libecdaa-dev
+RUN apt-get install libecdaa-tpm0
+RUN apt-get install libecdaa-tpm-dev
+RUN apt-get install libxtt0
+RUN apt-get install libxtt-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,10 @@
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED on)
 
 project(xtt-cpp
         VERSION "0.2.0"
         )
-
 set(XTT_CPP_VERSION ${PROJECT_VERSION})
 set(XTT_CPP_SOVERSION ${PROJECT_VERSION_MAJOR})
 
@@ -12,7 +13,6 @@ set(CMAKE_CXX_FLAGS_RELWITHSANITIZE "${CMAKE_CXX_FLAGS_RELWITHSANITIZE} -O2 -g -
 
 include(GNUInstallDirs)
 include(CTest)
-
 option(BUILD_SHARED_LIBS "Build as a shared library" ON)
 option(BUILD_STATIC_LIBS "Build as a static library" OFF)
 

--- a/asio/include/xtt/asio/server_context.inl
+++ b/asio/include/xtt/asio/server_context.inl
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2018 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -331,4 +331,3 @@ namespace asio {
 
 }   // namespace asio
 }   // namespace xtt
-

--- a/cpp/include/xtt/identity.hpp
+++ b/cpp/include/xtt/identity.hpp
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2018 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -79,4 +79,3 @@ namespace xtt {
 
 
 #endif
-


### PR DESCRIPTION
Created a Dockerfile to install boost and test xtt-cpp in the container. 
Added a travis.yml to build xtt-cpp, through our Docker using gcc and clang.
Fixes #2 