### PR TITLE
Improve serialization

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -46,6 +46,7 @@ if(BUILD_SHARED_LIBS)
         target_link_libraries(xtt-cpp
                 PUBLIC
                 xtt::xtt
+                ${Boost_LIBRARIES}
         )
 
         install(TARGETS xtt-cpp
@@ -77,6 +78,7 @@ if(BUILD_STATIC_LIBS)
         target_link_libraries(xtt-cpp_static
                 PUBLIC
                 xtt::xtt_static
+                ${Boost_LIBRARIES}
               )
 
         install(TARGETS xtt-cpp_static

--- a/cpp/include/xtt/group_identity.hpp
+++ b/cpp/include/xtt/group_identity.hpp
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2018 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,6 +40,10 @@ namespace xtt {
 
     class group_identity {
     public:
+        static
+        std::experimental::optional<group_identity>
+        deserialize(const unsigned char* serialized, std::size_t serialized_length);
+
         static
         std::experimental::optional<group_identity>
         deserialize(const std::vector<unsigned char>& serialized);

--- a/cpp/include/xtt/group_public_key_context.hpp
+++ b/cpp/include/xtt/group_public_key_context.hpp
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2018 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -75,6 +75,10 @@ namespace xtt {
          */
         static
         std::unique_ptr<group_public_key_context>
+        deserialize(const unsigned char* serialized, std::size_t serialized_length);
+
+        static
+        std::unique_ptr<group_public_key_context>
         deserialize(const std::vector<unsigned char>& serialized);
 
         /*
@@ -82,6 +86,13 @@ namespace xtt {
          *  two separate byte strings,
          *  one for the basename and the other for the GPK.
          */
+        static
+        std::unique_ptr<group_public_key_context>
+        from_gpk_and_basename(const unsigned char* gpk,
+                              std::size_t gpk_length,
+                              const unsigned char* basename,
+                              std::size_t basename_length);
+
         static
         std::unique_ptr<group_public_key_context>
         from_gpk_and_basename(const std::vector<unsigned char>& gpk,

--- a/cpp/include/xtt/identity.hpp
+++ b/cpp/include/xtt/identity.hpp
@@ -44,6 +44,10 @@ namespace xtt {
     public:
         static
         std::experimental::optional<identity>
+        deserialize(const unsigned char* serialized, std::size_t serialized_length);
+
+        static
+        std::experimental::optional<identity>
         deserialize(const std::vector<unsigned char>& serialized);
 
         static

--- a/cpp/include/xtt/longterm_key.hpp
+++ b/cpp/include/xtt/longterm_key.hpp
@@ -54,6 +54,10 @@ namespace xtt {
     public:
         static
         std::unique_ptr<longterm_key>
+        deserialize(const unsigned char* serialized, std::size_t serialized_length);
+
+        static
+        std::unique_ptr<longterm_key>
         deserialize(const std::vector<unsigned char>& serialized);
 
         static
@@ -100,6 +104,10 @@ namespace xtt {
 
     class longterm_private_key_ecdsap256 : public longterm_private_key {
     public:
+        static
+        std::unique_ptr<longterm_private_key>
+        deserialize(const unsigned char* serialized, std::size_t serialized_length);
+
         static
         std::unique_ptr<longterm_private_key>
         deserialize(const std::vector<unsigned char>& serialized);

--- a/cpp/include/xtt/pseudonym.hpp
+++ b/cpp/include/xtt/pseudonym.hpp
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2018 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -52,6 +52,10 @@ namespace xtt {
 
     class pseudonym_lrsw : public pseudonym {
     public:
+        static
+        std::unique_ptr<pseudonym>
+        deserialize(const unsigned char* serialized, std::size_t serialized_length);
+
         static
         std::unique_ptr<pseudonym>
         deserialize(const std::vector<unsigned char>& serialized);

--- a/cpp/include/xtt/server_certificate_context.hpp
+++ b/cpp/include/xtt/server_certificate_context.hpp
@@ -77,6 +77,10 @@ namespace xtt {
          */
         static
         std::unique_ptr<server_certificate_context>
+        deserialize(const unsigned char* serialized, std::size_t serialized_length);
+
+        static
+        std::unique_ptr<server_certificate_context>
         deserialize(const std::vector<unsigned char>& serialized);
 
         /*

--- a/cpp/src/group_identity.cpp
+++ b/cpp/src/group_identity.cpp
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2018 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,16 +30,22 @@ std::ostream& xtt::operator<<(std::ostream& stream, const xtt::group_identity& i
 }
 
 std::experimental::optional<group_identity>
-group_identity::deserialize(const std::vector<unsigned char>& serialized)
+group_identity::deserialize(const unsigned char* serialized, std::size_t serialized_length)
 {
-    if (sizeof(xtt_group_id) != serialized.size()) {
+    if (sizeof(xtt_group_id) != serialized_length) {
         return {};
     }
 
     group_identity ret;
-    ret.raw_ = *reinterpret_cast<const xtt_group_id*>(serialized.data());
+    ret.raw_ = *reinterpret_cast<const xtt_group_id*>(serialized);
 
     return ret;
+}
+
+std::experimental::optional<group_identity>
+group_identity::deserialize(const std::vector<unsigned char>& serialized)
+{
+    return deserialize(serialized.data(), serialized.size());
 }
 
 std::experimental::optional<group_identity>

--- a/cpp/src/identity.cpp
+++ b/cpp/src/identity.cpp
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2018 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,16 +32,22 @@ std::ostream& xtt::operator<<(std::ostream& stream, const xtt::identity& id)
 }
 
 std::experimental::optional<identity>
-identity::deserialize(const std::vector<unsigned char>& serialized)
+identity::deserialize(const unsigned char* serialized, std::size_t serialized_length)
 {
-    if (sizeof(xtt_identity_type) != serialized.size()) {
+    if (sizeof(xtt_identity_type) != serialized_length) {
         return {};
     }
 
     identity ret;
-    ret.raw_ = *reinterpret_cast<const xtt_identity_type*>(serialized.data());
+    ret.raw_ = *reinterpret_cast<const xtt_identity_type*>(serialized);
 
     return ret;
+}
+
+std::experimental::optional<identity>
+identity::deserialize(const std::vector<unsigned char>& serialized)
+{
+    return identity::deserialize(serialized.data(), serialized.size());
 }
 
 std::experimental::optional<identity>

--- a/cpp/src/longterm_key.cpp
+++ b/cpp/src/longterm_key.cpp
@@ -30,18 +30,24 @@ std::ostream& xtt::operator<<(std::ostream& stream, const xtt::longterm_key& key
 }
 
 std::unique_ptr<longterm_key>
-longterm_key_ecdsap256::deserialize(const std::vector<unsigned char>& serialized)
+longterm_key_ecdsap256::deserialize(const unsigned char* serialized, std::size_t serialized_length)
 {
-    if (sizeof(xtt_ecdsap256_pub_key) != serialized.size()) {
+    if (sizeof(xtt_ecdsap256_pub_key) != serialized_length) {
         return {};
     }
 
     std::unique_ptr<longterm_key> ret = std::make_unique<longterm_key_ecdsap256>();
     if (!ret)
         return {};
-    *(ret->get()) = *reinterpret_cast<const xtt_ecdsap256_pub_key*>(serialized.data());
+    *(ret->get()) = *reinterpret_cast<const xtt_ecdsap256_pub_key*>(serialized);
 
     return ret;
+}
+
+std::unique_ptr<longterm_key>
+longterm_key_ecdsap256::deserialize(const std::vector<unsigned char>& serialized)
+{
+    return deserialize(serialized.data(), serialized.size());
 }
 
 std::unique_ptr<longterm_key>
@@ -96,9 +102,9 @@ bool longterm_key::operator!=(const longterm_key& other) const
 }
 
 std::unique_ptr<longterm_private_key>
-longterm_private_key_ecdsap256::deserialize(const std::vector<unsigned char>& serialized)
+longterm_private_key_ecdsap256::deserialize(const unsigned char* serialized, std::size_t serialized_length)
 {
-    if (sizeof(xtt_ecdsap256_priv_key) != serialized.size()) {
+    if (sizeof(xtt_ecdsap256_priv_key) != serialized_length) {
         return {};
     }
 
@@ -106,9 +112,15 @@ longterm_private_key_ecdsap256::deserialize(const std::vector<unsigned char>& se
     if (!ret)
         return {};
 
-    *(ret->get()) = *reinterpret_cast<const xtt_ecdsap256_priv_key*>(serialized.data());
+    *(ret->get()) = *reinterpret_cast<const xtt_ecdsap256_priv_key*>(serialized);
 
     return std::move(ret);
+}
+
+std::unique_ptr<longterm_private_key>
+longterm_private_key_ecdsap256::deserialize(const std::vector<unsigned char>& serialized)
+{
+    return deserialize(serialized.data(), serialized.size());
 }
 
 std::unique_ptr<longterm_private_key>

--- a/cpp/src/pseudonym.cpp
+++ b/cpp/src/pseudonym.cpp
@@ -1,13 +1,13 @@
 /******************************************************************************
  *
  * Copyright 2018 Xaptum, Inc.
- * 
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- * 
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,9 +32,9 @@ std::ostream& xtt::operator<<(std::ostream& stream, const xtt::pseudonym& pseud)
 }
 
 std::unique_ptr<pseudonym>
-pseudonym_lrsw::deserialize(const std::vector<unsigned char>& serialized)
+pseudonym_lrsw::deserialize(const unsigned char* serialized, std::size_t serialized_length)
 {
-    if (sizeof(xtt_daa_pseudonym_lrsw) != serialized.size()) {
+    if (sizeof(xtt_daa_pseudonym_lrsw) != serialized_length) {
         return {};
     }
 
@@ -42,9 +42,15 @@ pseudonym_lrsw::deserialize(const std::vector<unsigned char>& serialized)
     if (!ret)
         return {};
 
-    *(ret->get()) = *reinterpret_cast<const xtt_daa_pseudonym_lrsw*>(serialized.data());
+    *(ret->get()) = *reinterpret_cast<const xtt_daa_pseudonym_lrsw*>(serialized);
 
     return std::move(ret);
+}
+
+std::unique_ptr<pseudonym>
+pseudonym_lrsw::deserialize(const std::vector<unsigned char>& serialized)
+{
+    return deserialize(serialized.data(), serialized.size());
 }
 
 std::unique_ptr<pseudonym>

--- a/cpp/src/server_certificate_context.cpp
+++ b/cpp/src/server_certificate_context.cpp
@@ -28,21 +28,27 @@ const unsigned char server_certificate_ecdsap256_dummy[XTT_SERVER_CERTIFICATE_EC
 const xtt_ecdsap256_priv_key server_privatekey_ecdsap256_dummy = {{0}};
 
 std::unique_ptr<server_certificate_context>
-server_certificate_context_ecdsap256::deserialize(const std::vector<unsigned char>& serialized)
+server_certificate_context_ecdsap256::deserialize(const unsigned char* serialized, std::size_t serialized_length)
 {
     size_t cert_len = XTT_SERVER_CERTIFICATE_ECDSAP256_LENGTH;
     size_t key_len = sizeof(xtt_ecdsap256_priv_key);
 
-    if (serialized.size() < (cert_len + key_len)) {
+    if (serialized_length < (cert_len + key_len)) {
         return {};
     }
 
-    std::vector<unsigned char>::const_iterator cert_begin{serialized.cbegin()};
+    const unsigned char* cert_begin = serialized;
 
-    std::vector<unsigned char>::const_iterator key_begin{serialized.cbegin() + cert_len};
+    const unsigned char* key_begin = serialized + cert_len;
 
     return from_certificate_and_key(std::vector<unsigned char>(cert_begin, cert_begin + cert_len),
                                     std::vector<unsigned char>(key_begin, key_begin + key_len));
+}
+
+std::unique_ptr<server_certificate_context>
+server_certificate_context_ecdsap256::deserialize(const std::vector<unsigned char>& serialized)
+{
+    return deserialize(serialized.data(), serialized.size());
 }
 
 std::unique_ptr<server_certificate_context>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,6 +21,11 @@ function(add_test_case case_file)
 
   add_executable(${case_name} ${case_file})
 
+  target_include_directories(${case_name}
+    PRIVATE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/cpp/src/internal>
+    )
+
   if(BUILD_SHARED_LIBS)
     target_link_libraries(${case_name} PRIVATE
       xtt-asio
@@ -43,6 +48,12 @@ function(add_test_case case_file)
 endfunction()
 
 set(XTT_CPP_TEST_FILES
+  internal-text_to_binary_Test.cpp
+  group_identity_Test.cpp
+  group_public_key_context_Test.cpp
+  identity_Test.cpp
+  longterm_key_Test.cpp
+  pseudonym_Test.cpp
   server_certificate_Test.cpp
   )
 

--- a/test/group_identity_Test.cpp
+++ b/test/group_identity_Test.cpp
@@ -1,0 +1,170 @@
+/******************************************************************************
+ *
+ * Copyright 2019 Xaptum, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#include <iostream>
+#include <vector>
+#include <string>
+#include <sstream>
+#include <iomanip>
+
+#include "test-utils.h"
+
+#include <xtt.hpp>
+
+#include <xtt.h>
+
+void length();
+void equality();
+void hash();
+void serialize_bin();
+void serialize_text();
+void string_to_bin();
+void serialize_bins_agree();
+
+int main()
+{
+    xtt::initialize_crypto();
+
+    length();
+    equality();
+    hash();
+    serialize_bin();
+    serialize_text();
+    string_to_bin();
+    serialize_bins_agree();
+}
+
+void length()
+{
+    std::cout << "Starting group_identity_Test::length...\n";
+
+    xtt::group_identity id;
+
+    TEST_ASSERT(id.length() == sizeof(xtt_group_id));
+}
+
+void equality()
+{
+    std::cout << "Starting group_identity_Test::equality...\n";
+
+    xtt::group_identity id1;
+    xtt_crypto_get_random(id1.get()->data, sizeof(xtt_group_id));
+
+    xtt::group_identity id2;
+    xtt_crypto_get_random(id2.get()->data, sizeof(xtt_group_id));
+
+    TEST_ASSERT(id1 == id1);
+    TEST_ASSERT(id1 != id2);
+}
+
+void hash()
+{
+    std::cout << "Starting group_identity_Test::hash...\n";
+
+    xtt::group_identity id1;
+    xtt_crypto_get_random(id1.get()->data, sizeof(xtt_group_id));
+
+    xtt::group_identity id2;
+    xtt_crypto_get_random(id2.get()->data, sizeof(xtt_group_id));
+
+    auto hash1 = std::hash<xtt::group_identity>()(id1);
+    auto hash2 = std::hash<xtt::group_identity>()(id2);
+    TEST_ASSERT(hash1 == hash1);
+    TEST_ASSERT(hash1 != hash2);
+}
+
+void serialize_bin()
+{
+    std::cout << "Starting group_identity_Test::serialize_bin...\n";
+
+    std::vector<unsigned char> id_as_bytes(sizeof(xtt_group_id));
+    xtt_crypto_get_random(id_as_bytes.data(), id_as_bytes.size());
+
+    auto maybe_id = xtt::group_identity::deserialize(id_as_bytes);
+
+    TEST_ASSERT(maybe_id);
+
+    auto id_serialized = (*maybe_id).serialize();
+
+    TEST_ASSERT(id_serialized.size() == sizeof(xtt_group_id));
+    TEST_ASSERT(id_as_bytes == id_serialized);
+}
+
+void serialize_text()
+{
+    std::cout << "Starting group_identity_Test::serialize_text...\n";
+
+    std::vector<unsigned char> id_as_bytes(sizeof(xtt_group_id));
+    xtt_crypto_get_random(id_as_bytes.data(), id_as_bytes.size());
+    std::stringstream ss;
+    ss << std::hex;
+    for (auto& b: id_as_bytes)
+        ss << std::uppercase << std::setw(2) << std::setfill('0') << (int)b;
+    std::string id_as_text = ss.str();
+    TEST_ASSERT(id_as_text.length() == 2*sizeof(xtt_group_id));
+
+    auto maybe_id = xtt::group_identity::deserialize(id_as_text);
+
+    TEST_ASSERT(maybe_id);
+
+    auto id_serialized = (*maybe_id).serialize_to_text();
+
+    TEST_ASSERT(id_as_text == id_serialized);
+
+    std::cout << "Group identity as string is: '" << id_as_text << "'"
+        << ", which gets serialized as: '" << *maybe_id << std::endl;
+}
+
+void string_to_bin()
+{
+    std::cout << "Starting group_identity_Test::string_to_bin...\n";
+
+    std::vector<unsigned char> id_as_bytes(sizeof(xtt_group_id));
+    xtt_crypto_get_random(id_as_bytes.data(), id_as_bytes.size());
+    std::stringstream ss;
+    ss << std::hex;
+    for (auto& b: id_as_bytes)
+        ss << std::uppercase << std::setw(2) << std::setfill('0') << (int)b;
+    std::string id_as_text = ss.str();
+    TEST_ASSERT(id_as_text.length() == 2*sizeof(xtt_group_id));
+
+    auto maybe_id = xtt::group_identity::deserialize(id_as_text);
+
+    TEST_ASSERT(maybe_id);
+
+    auto id_serialized = (*maybe_id).serialize();
+
+    TEST_ASSERT(id_as_bytes == id_serialized);
+}
+
+void serialize_bins_agree()
+{
+    std::cout << "Starting group_identity_Test::serialize_bins_agree...\n";
+
+    unsigned char id_as_bytes[sizeof(xtt_group_id)];
+    xtt_crypto_get_random(id_as_bytes, sizeof(id_as_bytes));
+
+    auto maybe_id = xtt::group_identity::deserialize(id_as_bytes, sizeof(id_as_bytes));
+
+    TEST_ASSERT(maybe_id);
+
+    auto id_serialized = (*maybe_id).serialize();
+
+    TEST_ASSERT(id_serialized.size() == sizeof(xtt_group_id));
+    TEST_ASSERT(0 == memcmp(id_as_bytes, id_serialized.data(), id_serialized.size()));
+}

--- a/test/group_public_key_context_Test.cpp
+++ b/test/group_public_key_context_Test.cpp
@@ -1,0 +1,221 @@
+/******************************************************************************
+ *
+ * Copyright 2019 Xaptum, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#include <iostream>
+#include <vector>
+#include <string>
+#include <sstream>
+#include <iomanip>
+
+#include "test-utils.h"
+
+#include <xtt.hpp>
+
+#include <xtt.h>
+
+void lrsw_clone();
+void lrsw_deserialize_bin_together();
+void lrsw_deserialize_bins_together_agree();
+void lrsw_deserialize_bin_separate();
+void lrsw_deserialize_text();
+void lrsw_deserialize_basename_too_long();
+void lrsw_deserialize_basename_bad_length();
+
+int main()
+{
+    xtt::initialize_crypto();
+
+    lrsw_clone();
+    lrsw_deserialize_bin_together();
+    lrsw_deserialize_bins_together_agree();
+    lrsw_deserialize_bin_separate();
+    lrsw_deserialize_text();
+    lrsw_deserialize_basename_too_long();
+    lrsw_deserialize_basename_bad_length();
+}
+
+void lrsw_clone()
+{
+    std::cout << "Starting group_public_key_context_Test::lrsw_clone...\n";
+
+    xtt::group_public_key_context_lrsw ctx;
+    TEST_ASSERT(ctx.get());
+
+    xtt_crypto_get_random((unsigned char*)ctx.get(), sizeof(xtt_group_public_key_context));
+
+    auto cloned_ctx = ctx.clone();
+    TEST_ASSERT(cloned_ctx->get());
+
+    TEST_ASSERT(cloned_ctx->get() != ctx.get());
+    TEST_ASSERT(0 == memcmp(cloned_ctx->get(), ctx.get(), sizeof(xtt_group_public_key_context)));
+}
+
+void lrsw_deserialize_bin_together()
+{
+    std::cout << "Starting group_public_key_context_Test::lrsw_deserialize_bin_together...\n";
+
+    std::vector<unsigned char> basename_as_bytes(23);
+    xtt_crypto_get_random(basename_as_bytes.data(), basename_as_bytes.size());
+
+    std::vector<unsigned char> gpk_as_bytes(sizeof(xtt_daa_group_pub_key_lrsw));
+    xtt_crypto_get_random(gpk_as_bytes.data(), gpk_as_bytes.size());
+
+    std::vector<unsigned char> all_together(gpk_as_bytes);
+    all_together.push_back(static_cast<unsigned char>(basename_as_bytes.size()));
+    all_together.insert(all_together.end(), basename_as_bytes.begin(), basename_as_bytes.end());
+    auto maybe_ctx = xtt::group_public_key_context_lrsw::deserialize(all_together);
+    TEST_ASSERT(maybe_ctx);
+
+    TEST_ASSERT(basename_as_bytes == maybe_ctx->get_basename());
+    TEST_ASSERT(gpk_as_bytes == maybe_ctx->get_gpk());
+
+    auto ctx_serialized = maybe_ctx->serialize();
+    TEST_ASSERT(ctx_serialized.size() == gpk_as_bytes.size() + 1 + basename_as_bytes.size());
+    TEST_ASSERT(ctx_serialized == all_together);
+}
+
+void lrsw_deserialize_bins_together_agree()
+{
+    std::cout << "Starting group_public_key_context_Test::lrsw_deserialize_bins_together_agree...\n";
+
+    unsigned char basename_as_bytes[23];
+    xtt_crypto_get_random(basename_as_bytes, sizeof(basename_as_bytes));
+
+    unsigned char gpk_as_bytes[sizeof(xtt_daa_group_pub_key_lrsw)];
+    xtt_crypto_get_random(gpk_as_bytes, sizeof(gpk_as_bytes));
+
+    unsigned char all_together[sizeof(gpk_as_bytes) + 1 + sizeof(basename_as_bytes)];
+    std::copy(gpk_as_bytes, gpk_as_bytes + sizeof(gpk_as_bytes), all_together);
+    all_together[sizeof(gpk_as_bytes)] = sizeof(basename_as_bytes);
+    std::copy(basename_as_bytes, basename_as_bytes + sizeof(basename_as_bytes), all_together + sizeof(gpk_as_bytes) + 1);
+    auto maybe_ctx = xtt::group_public_key_context_lrsw::deserialize(all_together, sizeof(all_together));
+    TEST_ASSERT(maybe_ctx);
+
+    TEST_ASSERT(maybe_ctx->get_basename().size() == sizeof(basename_as_bytes));
+    TEST_ASSERT(0 == memcmp(basename_as_bytes, maybe_ctx->get_basename().data(), sizeof(basename_as_bytes)));
+    TEST_ASSERT(maybe_ctx->get_gpk().size() == sizeof(gpk_as_bytes));
+    TEST_ASSERT(0 == memcmp(gpk_as_bytes, maybe_ctx->get_gpk().data(), sizeof(gpk_as_bytes)));
+
+    auto ctx_serialized = maybe_ctx->serialize();
+    TEST_ASSERT(ctx_serialized.size() == sizeof(all_together));
+    TEST_ASSERT(0 == memcmp(ctx_serialized.data(), all_together, sizeof(all_together)));
+}
+
+void lrsw_deserialize_bin_separate()
+{
+    std::cout << "Starting group_public_key_context_Test::lrsw_deserialize_bin_separate...\n";
+
+    std::vector<unsigned char> basename_as_bytes(23);
+    xtt_crypto_get_random(basename_as_bytes.data(), basename_as_bytes.size());
+
+    std::vector<unsigned char> gpk_as_bytes(sizeof(xtt_daa_group_pub_key_lrsw));
+    xtt_crypto_get_random(gpk_as_bytes.data(), gpk_as_bytes.size());
+
+    auto maybe_ctx = xtt::group_public_key_context_lrsw::from_gpk_and_basename(gpk_as_bytes,
+            basename_as_bytes);
+    TEST_ASSERT(maybe_ctx);
+
+    TEST_ASSERT(basename_as_bytes == maybe_ctx->get_basename());
+    TEST_ASSERT(gpk_as_bytes == maybe_ctx->get_gpk());
+}
+
+void lrsw_deserialize_bins_separate_agree()
+{
+    std::cout << "Starting group_public_key_context_Test::lrsw_deserialize_bins_separate_agree...\n";
+
+    unsigned char basename_as_bytes[23];
+    xtt_crypto_get_random(basename_as_bytes, sizeof(basename_as_bytes));
+
+    unsigned char gpk_as_bytes[sizeof(xtt_daa_group_pub_key_lrsw)];
+    xtt_crypto_get_random(gpk_as_bytes, sizeof(gpk_as_bytes));
+
+    auto maybe_ctx = xtt::group_public_key_context_lrsw::from_gpk_and_basename(gpk_as_bytes, sizeof(gpk_as_bytes),
+            basename_as_bytes, sizeof(basename_as_bytes));
+    TEST_ASSERT(maybe_ctx);
+
+    TEST_ASSERT(maybe_ctx->get_basename().size() == sizeof(basename_as_bytes));
+    TEST_ASSERT(0 == memcmp(basename_as_bytes, maybe_ctx->get_basename().data(), sizeof(basename_as_bytes)));
+    TEST_ASSERT(maybe_ctx->get_gpk().size() == sizeof(gpk_as_bytes));
+    TEST_ASSERT(0 == memcmp(gpk_as_bytes, maybe_ctx->get_gpk().data(), sizeof(gpk_as_bytes)));
+
+    unsigned char all_together[sizeof(gpk_as_bytes) + 1 + sizeof(basename_as_bytes)];
+    std::copy(gpk_as_bytes, gpk_as_bytes + sizeof(gpk_as_bytes), all_together);
+    all_together[sizeof(gpk_as_bytes)] = sizeof(basename_as_bytes);
+    std::copy(basename_as_bytes, basename_as_bytes + sizeof(basename_as_bytes), all_together + sizeof(gpk_as_bytes) + 1);
+    auto ctx_serialized = maybe_ctx->serialize();
+    TEST_ASSERT(ctx_serialized.size() == sizeof(all_together));
+    TEST_ASSERT(0 == memcmp(ctx_serialized.data(), all_together, sizeof(all_together)));
+}
+
+void lrsw_deserialize_text()
+{
+    std::cout << "Starting group_public_key_context_Test::lrsw_deserialize_text...\n";
+
+    std::string basename_as_text = "DEADBEEFCAFE";
+
+    std::vector<unsigned char> gpk_as_bytes(sizeof(xtt_daa_group_pub_key_lrsw));
+    xtt_crypto_get_random(gpk_as_bytes.data(), gpk_as_bytes.size());
+    std::stringstream ss;
+    ss << std::hex;
+    for (auto& b: gpk_as_bytes)
+        ss << std::uppercase << std::setw(2) << std::setfill('0') << (int)b;
+    std::string gpk_as_text = ss.str();
+    TEST_ASSERT(gpk_as_text.length() == 2*sizeof(xtt_daa_group_pub_key_lrsw));
+
+    auto maybe_ctx = xtt::group_public_key_context_lrsw::from_gpk_and_basename(gpk_as_text, basename_as_text);
+    TEST_ASSERT(maybe_ctx);
+
+    TEST_ASSERT(basename_as_text == maybe_ctx->get_basename_as_text());
+    TEST_ASSERT(gpk_as_text == maybe_ctx->get_gpk_as_text());
+
+    std::cout << "GPK as string is: '" << gpk_as_text << "'\n"
+        << "and basename as string is: '" << basename_as_text << "'\n"
+        << "which creates a group public key context as: '" << *maybe_ctx << std::endl;
+}
+
+void lrsw_deserialize_basename_too_long()
+{
+    std::cout << "Starting group_public_key_context_Test::lrsw_deserialize_basename_too_long...\n";
+
+    std::vector<unsigned char> basename_as_bytes(MAX_BASENAME_LENGTH+1);
+    xtt_crypto_get_random(basename_as_bytes.data(), basename_as_bytes.size());
+
+    std::vector<unsigned char> gpk_as_bytes(sizeof(xtt_daa_group_pub_key_lrsw));
+    xtt_crypto_get_random(gpk_as_bytes.data(), gpk_as_bytes.size());
+
+    auto maybe_ctx = xtt::group_public_key_context_lrsw::from_gpk_and_basename(gpk_as_bytes,
+            basename_as_bytes);
+    TEST_ASSERT(!maybe_ctx);
+}
+
+void lrsw_deserialize_basename_bad_length()
+{
+    std::cout << "Starting group_public_key_context_Test::lrsw_deserialize_basename_bad_length...\n";
+
+    std::vector<unsigned char> basename_as_bytes(23);
+    xtt_crypto_get_random(basename_as_bytes.data(), basename_as_bytes.size());
+
+    std::vector<unsigned char> gpk_as_bytes(sizeof(xtt_daa_group_pub_key_lrsw));
+    xtt_crypto_get_random(gpk_as_bytes.data(), gpk_as_bytes.size());
+
+    std::vector<unsigned char> all_together(gpk_as_bytes);
+    all_together.push_back(static_cast<unsigned char>(basename_as_bytes.size() + 1));   // nb. wrong size
+    all_together.insert(all_together.end(), basename_as_bytes.begin(), basename_as_bytes.end());
+    auto maybe_ctx = xtt::group_public_key_context_lrsw::deserialize(all_together);
+    TEST_ASSERT(!maybe_ctx);
+}

--- a/test/identity_Test.cpp
+++ b/test/identity_Test.cpp
@@ -1,0 +1,190 @@
+/******************************************************************************
+ *
+ * Copyright 2019 Xaptum, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#include <iostream>
+#include <vector>
+#include <string>
+
+#include "test-utils.h"
+
+#include <xtt.hpp>
+
+#include <xtt.h>
+
+void null();
+void equality();
+void hash();
+void serialize_bin();
+void serialize_text();
+void deserialize_text_handles_noncanon();
+void string_to_bin();
+void serialize_bins_agree();
+
+int main()
+{
+    xtt::initialize_crypto();
+
+    null();
+    hash();
+    equality();
+    serialize_bin();
+    serialize_text();
+    deserialize_text_handles_noncanon();
+    string_to_bin();
+    serialize_bins_agree();
+}
+
+void null()
+{
+    std::cout << "Starting identity_Test::null...\n";
+
+    xtt::identity id;
+    TEST_ASSERT(id.is_null());
+
+    xtt_identity_type null_id = xtt_null_identity;
+    TEST_ASSERT(0 == memcmp(null_id.data, id.get(), sizeof(xtt_identity_type)));
+}
+
+void equality()
+{
+    std::cout << "Starting identity_Test::equality...\n";
+
+    xtt::identity id1;
+    xtt_crypto_get_random(id1.get()->data, sizeof(xtt_identity_type));
+    TEST_ASSERT(!id1.is_null());
+
+    xtt::identity id2;
+    xtt_crypto_get_random(id2.get()->data, sizeof(xtt_identity_type));
+    TEST_ASSERT(!id2.is_null());
+
+    TEST_ASSERT(id1 == id1);
+    TEST_ASSERT(id1 != id2);
+}
+
+void hash()
+{
+    std::cout << "Starting identity_Test::hash...\n";
+
+    xtt::identity id1;
+    xtt_crypto_get_random(id1.get()->data, sizeof(xtt_identity_type));
+    TEST_ASSERT(!id1.is_null());
+
+    xtt::identity id2;
+    xtt_crypto_get_random(id2.get()->data, sizeof(xtt_identity_type));
+    TEST_ASSERT(!id2.is_null());
+
+    auto hash1 = std::hash<xtt::identity>()(id1);
+    auto hash2 = std::hash<xtt::identity>()(id2);
+    TEST_ASSERT(hash1 == hash1);
+    TEST_ASSERT(hash1 != hash2);
+}
+
+void serialize_bin()
+{
+    std::cout << "Starting identity_Test::serialize_bin...\n";
+
+    std::vector<unsigned char> id_as_bytes(sizeof(xtt_identity_type));
+    xtt_crypto_get_random(id_as_bytes.data(), id_as_bytes.size());
+
+    auto maybe_id = xtt::identity::deserialize(id_as_bytes);
+
+    TEST_ASSERT(maybe_id);
+
+    TEST_ASSERT(!(*maybe_id).is_null());
+
+    auto id_serialized = (*maybe_id).serialize();
+
+    TEST_ASSERT(id_serialized.size() == sizeof(xtt_identity_type));
+    TEST_ASSERT(id_as_bytes == id_serialized);
+}
+
+void serialize_text()
+{
+    std::cout << "Starting identity_Test::serialize_text...\n";
+
+    std::string id_as_string = "ff02::1:2";
+
+    auto maybe_id = xtt::identity::deserialize(id_as_string);
+
+    TEST_ASSERT(maybe_id);
+
+    TEST_ASSERT(!(*maybe_id).is_null());
+
+    auto id_serialized = (*maybe_id).serialize_to_text();
+
+    TEST_ASSERT(id_as_string == id_serialized);
+}
+
+void deserialize_text_handles_noncanon()
+{
+    std::cout << "Starting identity_Test::serialize_text_handles_noncanon...\n";
+
+    std::string id_as_string = "ff02:0:0000:0000:0000:0000:1:2";
+    std::string id_as_string_canon = "ff02::1:2";
+
+    auto maybe_id = xtt::identity::deserialize(id_as_string);
+
+    TEST_ASSERT(maybe_id);
+
+    TEST_ASSERT(!(*maybe_id).is_null());
+
+    auto id_serialized = (*maybe_id).serialize_to_text();
+
+    TEST_ASSERT(id_as_string_canon == id_serialized);
+
+    std::cout << "Identity as string is: '" << id_as_string << "'"
+        << ", which gets serialized as: '" << *maybe_id << std::endl;
+}
+
+void string_to_bin()
+{
+    std::cout << "Starting identity_Test::string_to_bin...\n";
+
+    std::vector<unsigned char> id_as_bytes = {0xFF, 0x02, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x02};
+    std::string id_as_string = "ff02::1:2";
+
+    auto maybe_id = xtt::identity::deserialize(id_as_string);
+
+    TEST_ASSERT(maybe_id);
+
+    TEST_ASSERT(!(*maybe_id).is_null());
+
+    auto id_serialized = (*maybe_id).serialize();
+
+    TEST_ASSERT(id_as_bytes == id_serialized);
+}
+
+void serialize_bins_agree()
+{
+    std::cout << "Starting identity_Test::serialize_bins_agree...\n";
+
+    unsigned char id_as_bytes[sizeof(xtt_identity_type)];
+    xtt_crypto_get_random(id_as_bytes, sizeof(id_as_bytes));
+
+    auto maybe_id = xtt::identity::deserialize(id_as_bytes, sizeof(id_as_bytes));
+
+    TEST_ASSERT(maybe_id);
+
+    TEST_ASSERT(!(*maybe_id).is_null());
+
+    auto id_serialized = (*maybe_id).serialize();
+
+    TEST_ASSERT(id_serialized.size() == sizeof(xtt_identity_type));
+    TEST_ASSERT(0 == memcmp(id_as_bytes, id_serialized.data(), id_serialized.size()));
+}

--- a/test/internal-text_to_binary_Test.cpp
+++ b/test/internal-text_to_binary_Test.cpp
@@ -1,0 +1,101 @@
+/******************************************************************************
+ *
+ * Copyright 2019 Xaptum, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#include <iostream>
+#include <vector>
+#include <string>
+
+#include "text_to_binary.hpp"
+
+#include "test-utils.h"
+
+#include <xtt.hpp>
+
+#include <xtt.h>
+
+void text_to_bin_to_text();
+void bin_to_text_to_bin();
+void lowercase_ok();
+
+int main()
+{
+    text_to_bin_to_text();
+    bin_to_text_to_bin();
+    lowercase_ok();
+}
+
+void text_to_bin_to_text()
+{
+    std::cout << "Starting internal-text_to_binary_Test::text_to_bin_to_text...\n";
+
+    std::vector<unsigned char> as_bytes(1024);
+    xtt_crypto_get_random(as_bytes.data(), as_bytes.size());
+
+    std::stringstream ss;
+    ss << std::hex;
+    for (auto& b: as_bytes)
+        ss << std::uppercase << std::setw(2) << std::setfill('0') << (int)b;
+    std::string as_string = ss.str();
+    TEST_ASSERT(as_string.length() == 2*as_bytes.size());
+
+    auto conv_to_bin = text_to_binary(as_string);
+    TEST_ASSERT(conv_to_bin == as_bytes);
+
+    auto conv_to_text = binary_to_text(conv_to_bin.data(), conv_to_bin.size());
+    TEST_ASSERT(conv_to_text == as_string);
+}
+
+void bin_to_text_to_bin()
+{
+    std::cout << "Starting internal-text_to_binary_Test::bin_to_text_to_bin...\n";
+
+    std::vector<unsigned char> as_bytes(1024);
+    xtt_crypto_get_random(as_bytes.data(), as_bytes.size());
+
+    auto conv_to_text = binary_to_text(as_bytes.data(), as_bytes.size());
+    TEST_ASSERT(conv_to_text.length() == 2*as_bytes.size());
+
+    auto conv_to_bin = text_to_binary(conv_to_text);
+    TEST_ASSERT(conv_to_bin == as_bytes);
+}
+
+void lowercase_ok()
+{
+    std::cout << "Starting internal-text_to_binary_Test::lowercase_ok...\n";
+
+    std::vector<unsigned char> as_bytes(255);
+    xtt_crypto_get_random(as_bytes.data(), as_bytes.size());
+
+    std::stringstream ss1;
+    ss1 << std::hex;
+    for (auto& b: as_bytes)
+        ss1 << std::nouppercase << std::setw(2) << std::setfill('0') << (int)b;
+    std::string as_string_lower = ss1.str();
+    std::stringstream ss2;
+    ss2 << std::hex;
+    for (auto& b: as_bytes)
+        ss2 << std::uppercase << std::setw(2) << std::setfill('0') << (int)b;
+    std::string as_string_upper = ss2.str();
+
+    auto bin_from_lower = text_to_binary(as_string_lower);
+    TEST_ASSERT(bin_from_lower == as_bytes);
+
+    auto bin_from_upper = text_to_binary(as_string_upper);
+    TEST_ASSERT(bin_from_upper == as_bytes);
+}
+

--- a/test/longterm_key_Test.cpp
+++ b/test/longterm_key_Test.cpp
@@ -1,0 +1,290 @@
+/******************************************************************************
+ *
+ * Copyright 2019 Xaptum, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#include <iostream>
+#include <vector>
+#include <string>
+#include <sstream>
+#include <iomanip>
+
+#include "test-utils.h"
+
+#include <xtt.hpp>
+#include <xtt.h>
+
+void ecdsap256_length();
+void ecdsap256_equality();
+void ecdsap256_clone();
+void ecdsap256_serialize_bin();
+void ecdsap256_serialize_text();
+void ecdsap256_string_to_bin();
+void ecdsap256_serialize_bins_agree();
+void ecdsap256_priv_length();
+void ecdsap256_priv_equality();
+void ecdsap256_priv_clone();
+void ecdsap256_priv_serialize_bin();
+void ecdsap256_priv_string_to_bin();
+void ecdsap256_priv_serialize_bins_agree();
+
+int main()
+{
+    xtt::initialize_crypto();
+
+    ecdsap256_length();
+    ecdsap256_equality();
+    ecdsap256_clone();
+    ecdsap256_serialize_bin();
+    ecdsap256_serialize_text();
+    ecdsap256_string_to_bin();
+    ecdsap256_serialize_bins_agree();
+    ecdsap256_priv_length();
+    ecdsap256_priv_equality();
+    ecdsap256_priv_clone();
+    ecdsap256_priv_serialize_bin();
+    ecdsap256_priv_string_to_bin();
+    ecdsap256_priv_serialize_bins_agree();
+}
+
+void ecdsap256_length()
+{
+    std::cout << "Starting longterm_key_Test::ecdsap256_length...\n";
+
+    xtt::longterm_key_ecdsap256 key;
+
+    TEST_ASSERT(key.length() == sizeof(xtt_ecdsap256_pub_key));
+}
+
+void ecdsap256_equality()
+{
+    std::cout << "Starting longterm_key_Test::ecdsap256_equality...\n";
+
+    xtt::longterm_key_ecdsap256 key1;
+    xtt_crypto_get_random(key1.get()->data, sizeof(xtt_ecdsap256_pub_key));
+
+    xtt::longterm_key_ecdsap256 key2;
+    xtt_crypto_get_random(key2.get()->data, sizeof(xtt_ecdsap256_pub_key));
+
+    TEST_ASSERT(key1 == key1);
+    TEST_ASSERT(key2 == key2);
+    TEST_ASSERT(key1 != key2);
+}
+
+void ecdsap256_clone()
+{
+    std::cout << "Starting longterm_key_Test::ecdsap256_clone...\n";
+
+    xtt::longterm_key_ecdsap256 key;
+    TEST_ASSERT(key.get());
+
+    xtt_crypto_get_random(key.get()->data, sizeof(xtt_ecdsap256_pub_key));
+
+    auto cloned_key = key.clone();
+    TEST_ASSERT(cloned_key->get());
+
+    TEST_ASSERT(cloned_key->get() != key.get());
+    TEST_ASSERT(0 == memcmp(cloned_key->get(), key.get(), sizeof(xtt_ecdsap256_pub_key)));
+}
+
+void ecdsap256_serialize_bin()
+{
+    std::cout << "Starting longterm_key_Test::ecdsap256_serialize_bin...\n";
+
+    std::vector<unsigned char> key_as_bytes(sizeof(xtt_ecdsap256_pub_key));
+    xtt_crypto_get_random(key_as_bytes.data(), key_as_bytes.size());
+
+    auto maybe_key = xtt::longterm_key_ecdsap256::deserialize(key_as_bytes);
+    TEST_ASSERT(maybe_key);
+
+    auto key_serialized = maybe_key->serialize();
+
+    TEST_ASSERT(key_serialized.size() == sizeof(xtt_ecdsap256_pub_key));
+    TEST_ASSERT(key_as_bytes == key_serialized);
+}
+
+void ecdsap256_serialize_text()
+{
+    std::cout << "Starting longterm_key_Test::ecdsap256_serialize_text...\n";
+
+    std::vector<unsigned char> key_as_bytes(sizeof(xtt_ecdsap256_pub_key));
+    xtt_crypto_get_random(key_as_bytes.data(), key_as_bytes.size());
+    std::stringstream ss;
+    ss << std::hex;
+    for (auto& b: key_as_bytes)
+        ss << std::uppercase << std::setw(2) << std::setfill('0') << (int)b;
+    std::string key_as_string = ss.str();
+
+    auto maybe_key = xtt::longterm_key_ecdsap256::deserialize(key_as_string);
+
+    TEST_ASSERT(maybe_key);
+
+    auto key_serialized = maybe_key->serialize_to_text();
+
+    TEST_ASSERT(key_as_string == key_serialized);
+
+    std::cout << "Longterm key as string is: '" << key_as_string << "'"
+        << ", which gets serialized as: '" << *maybe_key << std::endl;
+}
+
+void ecdsap256_string_to_bin()
+{
+    std::cout << "Starting longterm_key_Test::ecdsap256_string_to_bin...\n";
+
+    std::vector<unsigned char> key_as_bytes(sizeof(xtt_ecdsap256_priv_key));
+    xtt_crypto_get_random(key_as_bytes.data(), key_as_bytes.size());
+    std::stringstream ss;
+    ss << std::hex;
+    for (auto& b: key_as_bytes)
+        ss << std::uppercase << std::setw(2) << std::setfill('0') << (int)b;
+    std::string key_as_string = ss.str();
+
+    auto maybe_key = xtt::longterm_private_key_ecdsap256::deserialize(key_as_string);
+    TEST_ASSERT(maybe_key);
+
+    auto key_serialized = maybe_key->serialize();
+
+    TEST_ASSERT(key_as_bytes == key_serialized);
+}
+
+void ecdsap256_serialize_bins_agree()
+{
+    std::cout << "Starting longterm_key_Test::ecdsap256_serialize_bins_agree...\n";
+
+    unsigned char key_as_bytes[sizeof(xtt_ecdsap256_pub_key)];
+    xtt_crypto_get_random(key_as_bytes, sizeof(xtt_ecdsap256_pub_key));
+
+    auto maybe_key = xtt::longterm_key_ecdsap256::deserialize(key_as_bytes, sizeof(key_as_bytes));
+    TEST_ASSERT(maybe_key);
+
+    auto key_serialized = maybe_key->serialize();
+
+    TEST_ASSERT(key_serialized.size() == sizeof(xtt_ecdsap256_pub_key));
+    TEST_ASSERT(0 == memcmp(key_as_bytes, key_serialized.data(), key_serialized.size()));
+}
+
+void ecdsap256_priv_length()
+{
+    std::cout << "Starting longterm_key_Test::ecdsap256_priv_length...\n";
+
+    xtt::longterm_private_key_ecdsap256 key;
+
+    TEST_ASSERT(key.length() == sizeof(xtt_ecdsap256_priv_key));
+}
+
+void ecdsap256_priv_equality()
+{
+    std::cout << "Starting longterm_key_Test::ecdsap256_priv_equality...\n";
+
+    xtt::longterm_key_ecdsap256 key1;
+    xtt_crypto_get_random(key1.get()->data, sizeof(xtt_ecdsap256_pub_key));
+
+    xtt::longterm_key_ecdsap256 key2;
+    xtt_crypto_get_random(key2.get()->data, sizeof(xtt_ecdsap256_pub_key));
+
+    TEST_ASSERT(key1 == key1);
+    TEST_ASSERT(key2 == key2);
+    TEST_ASSERT(key1 != key2);
+}
+
+void ecdsap256_priv_clone()
+{
+    std::cout << "Starting longterm_key_Test::ecdsap256_priv_clone...\n";
+
+    xtt::longterm_private_key_ecdsap256 key;
+    TEST_ASSERT(key.get());
+
+    xtt_crypto_get_random(key.get()->data, sizeof(xtt_ecdsap256_priv_key));
+
+    auto cloned_key = key.clone();
+    TEST_ASSERT(cloned_key->get());
+
+    TEST_ASSERT(cloned_key->get() != key.get());
+    TEST_ASSERT(0 == memcmp(cloned_key->get(), key.get(), sizeof(xtt_ecdsap256_priv_key)));
+}
+
+void ecdsap256_priv_serialize_bin()
+{
+    std::cout << "Starting longterm_key_Test::ecdsap256_priv_serialize_bin...\n";
+
+    std::vector<unsigned char> key_as_bytes(sizeof(xtt_ecdsap256_priv_key));
+    xtt_crypto_get_random(key_as_bytes.data(), key_as_bytes.size());
+
+    auto maybe_key = xtt::longterm_private_key_ecdsap256::deserialize(key_as_bytes);
+    TEST_ASSERT(maybe_key);
+
+    auto key_serialized = maybe_key->serialize();
+
+    TEST_ASSERT(key_serialized.size() == sizeof(xtt_ecdsap256_priv_key));
+    TEST_ASSERT(key_as_bytes == key_serialized);
+}
+
+void ecdsap256_priv_serialize_text()
+{
+    std::cout << "Starting longterm_key_Test::ecdsap256_priv_serialize_text...\n";
+
+    std::vector<unsigned char> key_as_bytes(sizeof(xtt_ecdsap256_pub_key));
+    xtt_crypto_get_random(key_as_bytes.data(), key_as_bytes.size());
+    std::stringstream ss;
+    ss << std::hex;
+    for (auto& b: key_as_bytes)
+        ss << std::uppercase << std::setw(2) << std::setfill('0') << (int)b;
+    std::string key_as_string = ss.str();
+
+    auto maybe_key = xtt::longterm_key_ecdsap256::deserialize(key_as_string);
+
+    TEST_ASSERT(maybe_key);
+
+    auto key_serialized = maybe_key->serialize_to_text();
+
+    TEST_ASSERT(key_as_string == key_serialized);
+}
+
+void ecdsap256_priv_string_to_bin()
+{
+    std::cout << "Starting longterm_key_Test::ecdsap256_priv_string_to_bin...\n";
+
+    std::vector<unsigned char> key_as_bytes(sizeof(xtt_ecdsap256_priv_key));
+    xtt_crypto_get_random(key_as_bytes.data(), key_as_bytes.size());
+    std::stringstream ss;
+    ss << std::hex;
+    for (auto& b: key_as_bytes)
+        ss << std::uppercase << std::setw(2) << std::setfill('0') << (int)b;
+    std::string key_as_string = ss.str();
+
+    auto maybe_key = xtt::longterm_private_key_ecdsap256::deserialize(key_as_string);
+    TEST_ASSERT(maybe_key);
+
+    auto key_serialized = maybe_key->serialize();
+
+    TEST_ASSERT(key_as_bytes == key_serialized);
+}
+
+void ecdsap256_priv_serialize_bins_agree()
+{
+    std::cout << "Starting longterm_key_Test::ecdsap256_priv_serialize_bins_agree...\n";
+
+    unsigned char key_as_bytes[sizeof(xtt_ecdsap256_priv_key)];
+    xtt_crypto_get_random(key_as_bytes, sizeof(xtt_ecdsap256_priv_key));
+
+    auto maybe_key = xtt::longterm_private_key_ecdsap256::deserialize(key_as_bytes, sizeof(key_as_bytes));
+    TEST_ASSERT(maybe_key);
+
+    auto key_serialized = maybe_key->serialize();
+
+    TEST_ASSERT(key_serialized.size() == sizeof(xtt_ecdsap256_priv_key));
+    TEST_ASSERT(0 == memcmp(key_as_bytes, key_serialized.data(), key_serialized.size()));
+}

--- a/test/pseudonym_Test.cpp
+++ b/test/pseudonym_Test.cpp
@@ -1,0 +1,140 @@
+/******************************************************************************
+ *
+ * Copyright 2019 Xaptum, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
+#include <iostream>
+#include <vector>
+#include <string>
+#include <sstream>
+#include <iomanip>
+
+#include "test-utils.h"
+
+#include <xtt.hpp>
+
+#include <xtt.h>
+
+void lrsw_length();
+void lrsw_clone();
+void lrsw_equality();
+void lrsw_deserialize_bin();
+void lrsw_deserialize_bins_agree();
+void lrsw_deserialize_text();
+
+int main()
+{
+    xtt::initialize_crypto();
+
+    lrsw_length();
+    lrsw_clone();
+    lrsw_equality();
+    lrsw_deserialize_bin();
+    lrsw_deserialize_bins_agree();
+    lrsw_deserialize_text();
+}
+
+void lrsw_length()
+{
+    std::cout << "Starting pseudonym_Test::length...\n";
+
+    xtt::pseudonym_lrsw nym;
+
+    TEST_ASSERT(nym.length() == sizeof(xtt_daa_pseudonym_lrsw));
+}
+
+void lrsw_clone()
+{
+    std::cout << "Starting pseudonym_Test::lrsw_clone...\n";
+
+    xtt::pseudonym_lrsw nym;
+    TEST_ASSERT(nym.get());
+
+    xtt_crypto_get_random(nym.get()->data, sizeof(xtt_daa_pseudonym_lrsw));
+
+    auto cloned_nym = nym.clone();
+    TEST_ASSERT(cloned_nym->get());
+
+    TEST_ASSERT(cloned_nym->get() != nym.get());
+    TEST_ASSERT(0 == memcmp(cloned_nym->get(), nym.get(), sizeof(xtt_daa_pseudonym_lrsw)));
+}
+
+void lrsw_equality()
+{
+    std::cout << "Starting pseudonym_Test::lrsw_equality...\n";
+
+    xtt::pseudonym_lrsw nym1;
+    xtt_crypto_get_random(nym1.get()->data, sizeof(xtt_daa_pseudonym_lrsw));
+
+    xtt::pseudonym_lrsw nym2;
+    xtt_crypto_get_random(nym2.get()->data, sizeof(xtt_daa_pseudonym_lrsw));
+
+    TEST_ASSERT(nym1 == nym1);
+    TEST_ASSERT(nym2 == nym2);
+    TEST_ASSERT(nym1 != nym2);
+}
+
+void lrsw_deserialize_bin()
+{
+    std::cout << "Starting pseudonym_Test::lrsw_deserialize_bin...\n";
+
+    std::vector<unsigned char> nym_as_bytes(sizeof(xtt_daa_pseudonym_lrsw));
+    xtt_crypto_get_random(nym_as_bytes.data(), nym_as_bytes.size());
+
+    auto maybe_nym = xtt::pseudonym_lrsw::deserialize(nym_as_bytes);
+    TEST_ASSERT(maybe_nym);
+
+    auto nym_serialized = maybe_nym->serialize();
+    TEST_ASSERT(nym_serialized.size() == nym_as_bytes.size());
+    TEST_ASSERT(nym_serialized == nym_as_bytes);
+}
+
+void lrsw_deserialize_bins_agree()
+{
+    std::cout << "Starting pseudonym_Test::lrsw_deserialize_bins_agree...\n";
+
+    std::vector<unsigned char> nym_as_bytes(sizeof(xtt_daa_pseudonym_lrsw));
+    xtt_crypto_get_random(nym_as_bytes.data(), nym_as_bytes.size());
+
+    auto maybe_nym = xtt::pseudonym_lrsw::deserialize(nym_as_bytes);
+    TEST_ASSERT(maybe_nym);
+
+    auto nym_serialized = maybe_nym->serialize();
+
+    TEST_ASSERT(nym_serialized.size() == sizeof(xtt_ecdsap256_pub_key));
+    TEST_ASSERT(nym_as_bytes == nym_serialized);
+}
+
+void lrsw_deserialize_text()
+{
+    std::cout << "Starting pseudonym_Test::lrsw_deserialize_text...\n";
+
+    std::vector<unsigned char> nym_as_bytes(sizeof(xtt_daa_pseudonym_lrsw));
+    xtt_crypto_get_random(nym_as_bytes.data(), nym_as_bytes.size());
+    std::stringstream ss;
+    ss << std::hex;
+    for (auto& b: nym_as_bytes)
+        ss << std::uppercase << std::setw(2) << std::setfill('0') << (int)b;
+    std::string nym_as_text = ss.str();
+
+    auto maybe_nym = xtt::pseudonym_lrsw::deserialize(nym_as_text);
+    TEST_ASSERT(maybe_nym);
+
+    TEST_ASSERT(nym_as_text == maybe_nym->serialize_to_text());
+
+    std::cout << "Pseudonym as string is: '" << nym_as_text << "'\n"
+        << "which serializes as: '" << *maybe_nym << std::endl;
+}

--- a/test/server_certificate_Test.cpp
+++ b/test/server_certificate_Test.cpp
@@ -1,22 +1,73 @@
+/******************************************************************************
+ *
+ * Copyright 2019 Xaptum, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License
+ *
+ *****************************************************************************/
+
 #include <iostream>
 #include <vector>
 #include <string>
+#include <sstream>
+#include <iomanip>
 
 #include "test-utils.h"
 
 #include <xtt.hpp>
 
-void swap_moves_pointers();
+#include <xtt.h>
+
+void ecdsap256_clone();
+void ecdsap256_swap_moves_pointers();
+void ecdsap256_clone_moves_pointers();
+void ecdsap256_deserialize_bin_together();
+void ecdsap256_deserialize_bin_separate();
+void ecdsap256_deserialize_text();
 
 int main()
 {
     xtt::initialize_crypto();
 
-    swap_moves_pointers();
+    ecdsap256_clone();
+    ecdsap256_swap_moves_pointers();
+    ecdsap256_clone_moves_pointers();
+    ecdsap256_deserialize_bin_together();
+    ecdsap256_deserialize_bin_separate();
+    ecdsap256_deserialize_text();
 }
 
-void swap_moves_pointers()
+void ecdsap256_clone()
 {
+    std::cout << "Starting server_certificate_Test::ecdsap256_clone...\n";
+
+    xtt::server_certificate_context_ecdsap256 ctx;
+    TEST_ASSERT(ctx.get());
+
+    xtt_crypto_get_random((unsigned char*)ctx.get(), sizeof(xtt_server_certificate_context));
+
+    auto cloned_ctx = ctx.clone();
+    TEST_ASSERT(cloned_ctx->get());
+
+    TEST_ASSERT(ctx.get_certificate() == cloned_ctx->get_certificate());
+    TEST_ASSERT(ctx.get_private_key() == cloned_ctx->get_private_key());
+    TEST_ASSERT(ctx.get_certificate() != cloned_ctx->get_private_key());
+}
+
+void ecdsap256_swap_moves_pointers()
+{
+    std::cout << "Starting server_certificate_Test::ecdsap256_clone...\n";
+
     // Default ctor
     xtt::server_certificate_context_ecdsap256 cert_ctx_1;
     unsigned char* serialized_ptr_1 = (unsigned char*)cert_ctx_1.get()->serialized_certificate;
@@ -42,4 +93,96 @@ void swap_moves_pointers()
     unsigned char* serialized_ptr_4 = (unsigned char*)cert_ctx_4.get()->serialized_certificate;
     TEST_ASSERT(serialized_ptr_4 == cert_ctx_4.get()->serialized_certificate_raw);
     TEST_ASSERT(serialized_ptr_4 != serialized_ptr_1);
+}
+
+void ecdsap256_clone_moves_pointers()
+{
+    std::cout << "Starting server_certificate_Test::ecdsap256_clone_moves_pointers...\n";
+
+    xtt::server_certificate_context_ecdsap256 ctx;
+    TEST_ASSERT(ctx.get());
+
+    xtt_crypto_get_random((unsigned char*)ctx.get(), sizeof(xtt_server_certificate_context));
+    unsigned char* serialized_ptr = (unsigned char*)ctx.get()->serialized_certificate;
+
+    auto cloned_ctx = ctx.clone();
+    TEST_ASSERT(cloned_ctx->get());
+
+    TEST_ASSERT(cloned_ctx->get() != ctx.get());
+    TEST_ASSERT(0 != memcmp(cloned_ctx->get(), ctx.get(), sizeof(xtt_server_certificate_context)));
+
+    unsigned char* serialized_ptr_cloned = (unsigned char*)cloned_ctx->get()->serialized_certificate;
+    TEST_ASSERT(serialized_ptr == (unsigned char*)ctx.get()->serialized_certificate);
+    TEST_ASSERT(serialized_ptr != serialized_ptr_cloned);
+}
+
+void ecdsap256_deserialize_bin_together()
+{
+    std::cout << "Starting server_certificate_Test::ecdsap256_deserialize_bin_together...\n";
+
+    std::vector<unsigned char> certificate_as_bytes(XTT_SERVER_CERTIFICATE_ECDSAP256_LENGTH);
+    xtt_crypto_get_random(certificate_as_bytes.data(), certificate_as_bytes.size());
+
+    std::vector<unsigned char> private_key_as_bytes(sizeof(xtt_ecdsap256_priv_key));
+    xtt_crypto_get_random(private_key_as_bytes.data(), private_key_as_bytes.size());
+
+    std::vector<unsigned char> all_together(certificate_as_bytes);
+    all_together.insert(all_together.end(), private_key_as_bytes.begin(), private_key_as_bytes.end());
+    auto maybe_ctx = xtt::server_certificate_context_ecdsap256::deserialize(all_together);
+    TEST_ASSERT(maybe_ctx);
+
+    TEST_ASSERT(certificate_as_bytes == maybe_ctx->get_certificate());
+    TEST_ASSERT(private_key_as_bytes == maybe_ctx->get_private_key());
+
+    auto ctx_serialized = maybe_ctx->serialize();
+    TEST_ASSERT(ctx_serialized.size() == private_key_as_bytes.size() + certificate_as_bytes.size());
+    TEST_ASSERT(ctx_serialized == all_together);
+}
+
+void ecdsap256_deserialize_bin_separate()
+{
+    std::cout << "Starting server_certificate_Test::ecdsap256_deserialize_bin_separate...\n";
+
+    std::vector<unsigned char> certificate_as_bytes(XTT_SERVER_CERTIFICATE_ECDSAP256_LENGTH);
+    xtt_crypto_get_random(certificate_as_bytes.data(), certificate_as_bytes.size());
+
+    std::vector<unsigned char> private_key_as_bytes(sizeof(xtt_ecdsap256_priv_key));
+    xtt_crypto_get_random(private_key_as_bytes.data(), private_key_as_bytes.size());
+
+    auto maybe_ctx = xtt::server_certificate_context_ecdsap256::from_certificate_and_key(certificate_as_bytes,
+            private_key_as_bytes);
+    TEST_ASSERT(maybe_ctx);
+
+    TEST_ASSERT(certificate_as_bytes == maybe_ctx->get_certificate());
+    TEST_ASSERT(private_key_as_bytes == maybe_ctx->get_private_key());
+}
+
+void ecdsap256_deserialize_text()
+{
+    std::cout << "Starting server_certificate_Test::ecdsap256_deserialize_text_separate...\n";
+
+    std::vector<unsigned char> certificate_as_bytes(XTT_SERVER_CERTIFICATE_ECDSAP256_LENGTH);
+    xtt_crypto_get_random(certificate_as_bytes.data(), certificate_as_bytes.size());
+    std::stringstream ss1;
+    ss1 << std::hex;
+    for (auto& b: certificate_as_bytes)
+        ss1 << std::uppercase << std::setw(2) << std::setfill('0') << (int)b;
+    std::string certificate_as_text = ss1.str();
+    TEST_ASSERT(certificate_as_text.length() == 2*XTT_SERVER_CERTIFICATE_ECDSAP256_LENGTH);
+
+    std::vector<unsigned char> private_key_as_bytes(sizeof(xtt_ecdsap256_priv_key));
+    xtt_crypto_get_random(private_key_as_bytes.data(), private_key_as_bytes.size());
+    std::stringstream ss2;
+    ss2 << std::hex;
+    for (auto& b: private_key_as_bytes)
+        ss2 << std::uppercase << std::setw(2) << std::setfill('0') << (int)b;
+    std::string private_key_as_text = ss2.str();
+    TEST_ASSERT(private_key_as_text.length() == 2*sizeof(xtt_ecdsap256_priv_key));
+
+    auto maybe_ctx = xtt::server_certificate_context_ecdsap256::from_certificate_and_key(certificate_as_text,
+            private_key_as_text);
+    TEST_ASSERT(maybe_ctx);
+
+    TEST_ASSERT(certificate_as_text == maybe_ctx->get_certificate_as_text());
+    TEST_ASSERT(private_key_as_text == maybe_ctx->get_private_key_as_text());
 }


### PR DESCRIPTION
This series:
- Adds `unsigned char*` deserialization to objects that previously only had `std::vector<unsigned char>` deserializers (in addition to `std::string`). The `std::vector` functions now just call through to the `unsigned char*` ones, but this gives the user more options (this came up with Fej's work on the XMB).
- Adds canonical IPv6 textual (de)serialization for the `identity` class (using Boost)
- Adds tests of these new serialization functionalities