### PR TITLE
support std::optional or std::experimental::optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
-set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
 
 project(xtt-cpp
@@ -8,7 +7,7 @@ project(xtt-cpp
 set(XTT_CPP_VERSION ${PROJECT_VERSION})
 set(XTT_CPP_SOVERSION ${PROJECT_VERSION_MAJOR})
 
-add_compile_options(-std=c++14 -Wall -Wextra -Wno-missing-field-initializers)
+add_compile_options(-Wall -Wextra -Wno-missing-field-initializers)
 set(CMAKE_CXX_FLAGS_RELWITHSANITIZE "${CMAKE_CXX_FLAGS_RELWITHSANITIZE} -O2 -g -fsanitize=address,undefined -fsanitize=unsigned-integer-overflow")
 set(CMAKE_CXX_FLAGS_DEV "${CMAKE_CXX_FLAGS_RELEASE} -Werror")
 set(CMAKE_CXX_FLAGS_DEVDEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Werror")
@@ -29,6 +28,19 @@ find_package(Threads REQUIRED QUIET)
 find_package(Boost 1.66 COMPONENTS system thread REQUIRED QUIET)
 
 find_package(xtt 0.10.2 REQUIRED QUIET)
+
+# In newer C++17 compilers, optional has been moved from std::experimental to std.
+include(CheckIncludeFileCXX)
+check_include_file_cxx("optional" HAVE_OPTIONAL)
+if(HAVE_OPTIONAL)
+  set(CMAKE_CXX_STANDARD 17)
+  set(OPTIONAL_NS "::std")
+  set(OPTIONAL_H "<optional>")
+else()
+  set(CMAKE_CXX_STANDARD 14)
+  set(OPTIONAL_NS "::std::experimental")
+  set(OPTIONAL_H "<experimental/optional>")
+endif()
 
 add_subdirectory(cpp)
 add_subdirectory(asio)

--- a/asio/include/xtt/asio/server_context.hpp
+++ b/asio/include/xtt/asio/server_context.hpp
@@ -56,7 +56,7 @@ namespace asio {
 
         std::unique_ptr<longterm_key> get_clients_longterm_key() const;
 
-        std::experimental::optional<identity> get_clients_identity() const;
+        OPTIONAL_NS::optional<identity> get_clients_identity() const;
 
         /*
          * Begin the server's end of an XTT handshake, from the very first client message.

--- a/asio/src/server_context.cpp
+++ b/asio/src/server_context.cpp
@@ -78,7 +78,7 @@ std::unique_ptr<longterm_key> server_context::get_clients_longterm_key() const
     return handshake_ctx_.get_clients_longterm_key();
 }
 
-std::experimental::optional<identity> server_context::get_clients_identity() const
+OPTIONAL_NS::optional<identity> server_context::get_clients_identity() const
 {
     return handshake_ctx_.get_clients_identity();
 }

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -14,6 +14,8 @@
 
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
+configure_file("config.hpp.in" "include/xtt/config.hpp")
+
 set(XTT_CPP_SRC_FILES
         ${CMAKE_CURRENT_LIST_DIR}/src/crypto.cpp
         ${CMAKE_CURRENT_LIST_DIR}/src/server_handshake_context.cpp
@@ -24,7 +26,6 @@ set(XTT_CPP_SRC_FILES
         ${CMAKE_CURRENT_LIST_DIR}/src/group_identity.cpp
         ${CMAKE_CURRENT_LIST_DIR}/src/longterm_key.cpp
         )
-
 
 ################################################################################
 # Shared Libary
@@ -40,6 +41,7 @@ if(BUILD_SHARED_LIBS)
         target_include_directories(xtt-cpp
                 PUBLIC
                 $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+                $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
                 $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
         )
 
@@ -94,6 +96,7 @@ endif()
 ################################################################################
 install(FILES include/xtt.hpp DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 install(DIRECTORY include/xtt DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/xtt DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 ################################################################################
 # pkgconfig

--- a/cpp/config.hpp.in
+++ b/cpp/config.hpp.in
@@ -1,6 +1,6 @@
 /******************************************************************************
  *
- * Copyright 2018 Xaptum, Inc.
+ * Copyright 2019 Xaptum, Inc.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,20 +16,11 @@
  *
  *****************************************************************************/
 
-#ifndef XTT_CPP_XTTCPP_HPP
-#define XTT_CPP_XTTCPP_HPP
+#ifndef XTT_CPP_CONFIG_HPP
+#define XTT_CPP_CONFIG_HPP
 #pragma once
 
-#include <xtt/config.hpp>
-#include <xtt/crypto.hpp>
-#include <xtt/server_handshake_context.hpp>
-#include <xtt/server_cookie_context.hpp>
-#include <xtt/group_public_key_context.hpp>
-#include <xtt/server_certificate_context.hpp>
-#include <xtt/identity.hpp>
-#include <xtt/group_identity.hpp>
-#include <xtt/longterm_key.hpp>
-#include <xtt/pseudonym.hpp>
-#include <xtt/types.hpp>
+#define OPTIONAL_NS ${OPTIONAL_NS}
+#define OPTIONAL_H ${OPTIONAL_H}
 
 #endif

--- a/cpp/include/xtt/crypto.hpp
+++ b/cpp/include/xtt/crypto.hpp
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <xtt/crypto_wrapper.h>
+#include <xtt/config.hpp>
 
 namespace xtt {
     int initialize_crypto();

--- a/cpp/include/xtt/group_identity.hpp
+++ b/cpp/include/xtt/group_identity.hpp
@@ -22,10 +22,12 @@
 
 #include <xtt/crypto_types.h>
 
+#include <xtt/config.hpp>
+
 #include <string>
 #include <vector>
 #include <functional>
-#include <experimental/optional>
+#include OPTIONAL_H
 
 namespace xtt { class group_identity; }
 namespace std {
@@ -41,15 +43,15 @@ namespace xtt {
     class group_identity {
     public:
         static
-        std::experimental::optional<group_identity>
+        OPTIONAL_NS::optional<group_identity>
         deserialize(const unsigned char* serialized, std::size_t serialized_length);
 
         static
-        std::experimental::optional<group_identity>
+        OPTIONAL_NS::optional<group_identity>
         deserialize(const std::vector<unsigned char>& serialized);
 
         static
-        std::experimental::optional<group_identity>
+        OPTIONAL_NS::optional<group_identity>
         deserialize(const std::string& serialized);
 
     public:

--- a/cpp/include/xtt/group_public_key_context.hpp
+++ b/cpp/include/xtt/group_public_key_context.hpp
@@ -21,8 +21,9 @@
 #pragma once
 
 #include <xtt/context.h>
-
 #include <xtt/group_identity.hpp>
+
+#include <xtt/config.hpp>
 
 #include <vector>
 #include <memory>

--- a/cpp/include/xtt/identity.hpp
+++ b/cpp/include/xtt/identity.hpp
@@ -22,9 +22,11 @@
 
 #include <xtt/crypto_types.h>
 
+#include <xtt/config.hpp>
+
 #include <string>
 #include <vector>
-#include <experimental/optional>
+#include OPTIONAL_H
 
 namespace xtt { class identity; }
 namespace std {
@@ -43,15 +45,15 @@ namespace xtt {
 
     public:
         static
-        std::experimental::optional<identity>
+        OPTIONAL_NS::optional<identity>
         deserialize(const unsigned char* serialized, std::size_t serialized_length);
 
         static
-        std::experimental::optional<identity>
+        OPTIONAL_NS::optional<identity>
         deserialize(const std::vector<unsigned char>& serialized);
 
         static
-        std::experimental::optional<identity>
+        OPTIONAL_NS::optional<identity>
         deserialize(const std::string& serialized);
 
     public:

--- a/cpp/include/xtt/longterm_key.hpp
+++ b/cpp/include/xtt/longterm_key.hpp
@@ -22,6 +22,8 @@
 
 #include <xtt/crypto_types.h>
 
+#include <xtt/config.hpp>
+
 #include <string>
 #include <vector>
 #include <memory>

--- a/cpp/include/xtt/pseudonym.hpp
+++ b/cpp/include/xtt/pseudonym.hpp
@@ -22,6 +22,8 @@
 
 #include <xtt/crypto_types.h>
 
+#include <xtt/config.hpp>
+
 #include <string>
 #include <vector>
 #include <memory>

--- a/cpp/include/xtt/server_certificate_context.hpp
+++ b/cpp/include/xtt/server_certificate_context.hpp
@@ -22,6 +22,8 @@
 
 #include <xtt/context.h>
 
+#include <xtt/config.hpp>
+
 #include <vector>
 #include <string>
 #include <utility>

--- a/cpp/include/xtt/server_cookie_context.hpp
+++ b/cpp/include/xtt/server_cookie_context.hpp
@@ -22,6 +22,8 @@
 
 #include <xtt/context.h>
 
+#include <xtt/config.hpp>
+
 namespace xtt {
 
     class server_cookie_context {

--- a/cpp/include/xtt/server_handshake_context.hpp
+++ b/cpp/include/xtt/server_handshake_context.hpp
@@ -23,6 +23,7 @@
 #include <xtt/context.h>
 #include <xtt/messages.h>
 
+#include <xtt/config.hpp>
 #include <xtt/pseudonym.hpp>
 #include <xtt/longterm_key.hpp>
 #include <xtt/identity.hpp>
@@ -33,7 +34,7 @@
 #include <xtt/server_cookie_context.hpp>
 
 #include <memory>
-#include <experimental/optional>
+#include OPTIONAL_H
 
 namespace xtt {
 
@@ -52,15 +53,15 @@ namespace xtt {
                                  unsigned char *out_buffer,
                                  uint16_t out_buffer_size);
 
-        std::experimental::optional<version> get_version() const;
+        OPTIONAL_NS::optional<version> get_version() const;
 
-        std::experimental::optional<suite_spec> get_suite_spec() const;
+        OPTIONAL_NS::optional<suite_spec> get_suite_spec() const;
 
         std::unique_ptr<pseudonym> get_clients_pseudonym() const;
 
         std::unique_ptr<longterm_key> get_clients_longterm_key() const;
 
-        std::experimental::optional<identity> get_clients_identity() const;
+        OPTIONAL_NS::optional<identity> get_clients_identity() const;
 
         const struct xtt_server_handshake_context* get() const;
         struct xtt_server_handshake_context* get();

--- a/cpp/include/xtt/types.hpp
+++ b/cpp/include/xtt/types.hpp
@@ -20,6 +20,8 @@
 #define XTT_CPP_TYPES_HPP
 #pragma once
 
+#include <xtt/config.hpp>
+
 #include <xtt/crypto_types.h>
 
 #include <ostream>

--- a/cpp/src/group_identity.cpp
+++ b/cpp/src/group_identity.cpp
@@ -29,7 +29,7 @@ std::ostream& xtt::operator<<(std::ostream& stream, const xtt::group_identity& i
     return stream << id.serialize_to_text();
 }
 
-std::experimental::optional<group_identity>
+OPTIONAL_NS::optional<group_identity>
 group_identity::deserialize(const unsigned char* serialized, std::size_t serialized_length)
 {
     if (sizeof(xtt_group_id) != serialized_length) {
@@ -42,13 +42,13 @@ group_identity::deserialize(const unsigned char* serialized, std::size_t seriali
     return ret;
 }
 
-std::experimental::optional<group_identity>
+OPTIONAL_NS::optional<group_identity>
 group_identity::deserialize(const std::vector<unsigned char>& serialized)
 {
     return deserialize(serialized.data(), serialized.size());
 }
 
-std::experimental::optional<group_identity>
+OPTIONAL_NS::optional<group_identity>
 group_identity::deserialize(const std::string& serialized)
 {
     return deserialize(text_to_binary(serialized));

--- a/cpp/src/identity.cpp
+++ b/cpp/src/identity.cpp
@@ -35,7 +35,7 @@ std::ostream& xtt::operator<<(std::ostream& stream, const xtt::identity& id)
     return stream << id.serialize_to_text();
 }
 
-std::experimental::optional<identity>
+OPTIONAL_NS::optional<identity>
 identity::deserialize(const unsigned char* serialized, std::size_t serialized_length)
 {
     if (sizeof(xtt_identity_type) != serialized_length) {
@@ -48,13 +48,13 @@ identity::deserialize(const unsigned char* serialized, std::size_t serialized_le
     return ret;
 }
 
-std::experimental::optional<identity>
+OPTIONAL_NS::optional<identity>
 identity::deserialize(const std::vector<unsigned char>& serialized)
 {
     return identity::deserialize(serialized.data(), serialized.size());
 }
 
-std::experimental::optional<identity>
+OPTIONAL_NS::optional<identity>
 identity::deserialize(const std::string& serialized_as_text)
 {
     using boost::asio::ip::make_address_v6;

--- a/cpp/src/internal/text_to_binary.hpp
+++ b/cpp/src/internal/text_to_binary.hpp
@@ -20,14 +20,16 @@
 #define XTT_CPP_INTERNAL_TEXTTOBINARY_HPP
 #pragma once
 
+#include <xtt/config.hpp>
+
 #include <vector>
 #include <string>
 #include <sstream>
 #include <iomanip>
-#include <experimental/optional>
+#include OPTIONAL_H
 
 inline
-std::experimental::optional<unsigned char> ascii_to_byte(const char value);
+OPTIONAL_NS::optional<unsigned char> ascii_to_byte(const char value);
 
 inline
 std::string binary_to_text(const unsigned char *binary, uint16_t size) {
@@ -62,19 +64,19 @@ std::vector<unsigned char> text_to_binary(const std::string& text)
     return ret;
 }
 
-std::experimental::optional<unsigned char> ascii_to_byte(const char value)
+OPTIONAL_NS::optional<unsigned char> ascii_to_byte(const char value)
 {
     if (value < 0)
         return {};
 
     if (value >= '0' && value <= '9') {
-        return std::experimental::optional<unsigned char>(static_cast<unsigned char>(value - '0'));
+        return OPTIONAL_NS::optional<unsigned char>(static_cast<unsigned char>(value - '0'));
     }
     if (value >= 'A' && value <= 'F') {
-        return std::experimental::optional<unsigned char>(static_cast<unsigned char>(value - 'A' + 10));
+        return OPTIONAL_NS::optional<unsigned char>(static_cast<unsigned char>(value - 'A' + 10));
     }
     if (value >= 'a' && value <= 'f') {
-        return std::experimental::optional<unsigned char>(static_cast<unsigned char>(value - 'a' + 10));
+        return OPTIONAL_NS::optional<unsigned char>(static_cast<unsigned char>(value - 'a' + 10));
     }
 
     return {};

--- a/cpp/src/server_handshake_context.cpp
+++ b/cpp/src/server_handshake_context.cpp
@@ -41,7 +41,7 @@ server_handshake_context::server_handshake_context(unsigned char *in_buffer,
     }
 }
 
-std::experimental::optional<version> server_handshake_context::get_version() const
+OPTIONAL_NS::optional<version> server_handshake_context::get_version() const
 {
     xtt_version current_version;
     if (XTT_RETURN_SUCCESS != xtt_get_version(&current_version, &handshake_ctx_)) {
@@ -51,7 +51,7 @@ std::experimental::optional<version> server_handshake_context::get_version() con
     return static_cast<version>(current_version);
 }
 
-std::experimental::optional<suite_spec> server_handshake_context::get_suite_spec() const
+OPTIONAL_NS::optional<suite_spec> server_handshake_context::get_suite_spec() const
 {
     xtt_suite_spec current_suite_spec;
     if (XTT_RETURN_SUCCESS != xtt_get_suite_spec(&current_suite_spec, &handshake_ctx_)) {
@@ -109,7 +109,7 @@ std::unique_ptr<longterm_key> server_handshake_context::get_clients_longterm_key
     }
 }
 
-std::experimental::optional<identity> server_handshake_context::get_clients_identity() const
+OPTIONAL_NS::optional<identity> server_handshake_context::get_clients_identity() const
 {
     xtt_identity_type assigned_identity;
     if (XTT_RETURN_SUCCESS != xtt_get_clients_identity(&assigned_identity, &handshake_ctx_)) {


### PR DESCRIPTION
Newer compilers, specifically the latest Clang on OSX, have removed
`std::experimental::optional` entirely. This leads to two issues:

1) The imports and namespaces for `optional` have changed.
2) `optional` is only supported for C++17 and above, not C++14.

This commit uses CMake to detect which namespace contains optional,
sets a macro with the detected import and namespace, and updates all
usages of optional to use these detected import and namespaces.

Addditionally, if optional has been moved out of the experimental
namespace, it upgrades the required standard to C++17.