### PR TITLE
boost: upgrade to Boost 1.71

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -15,10 +15,10 @@ RUN apt-get -qq update \
        && rm cmake-3.11.4-Linux-x86_64.tar.gz
 
 #INSTALLS BOOST
-RUN wget http://downloads.sourceforge.net/project/boost/boost/1.66.0/boost_1_66_0.tar.gz \
-  && tar xfz boost_1_66_0.tar.gz \
-  && rm boost_1_66_0.tar.gz \
-  && cd boost_1_66_0 \
+RUN wget https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.gz \
+  && tar xfz boost_1_71_0.tar.gz \
+  && rm boost_1_71_0.tar.gz \
+  && cd boost_1_71_0 \
   && ./bootstrap.sh --prefix=/usr/local --with-libraries=system,thread \
   && ./b2 install \
   && cd ..

--- a/.docker/Makefile
+++ b/.docker/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.1.1
+VERSION := 0.1.2
 PREFIX  := xaptumeng/xtt-cpp-build
 
 .DEFAULT_GOAL := all

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_script:
 
 
 script:
-  - docker run -v $(pwd):/xttcpp/ -d -t --name xttcpp xaptumeng/xtt-cpp-build:0.1.1
+  - docker run -v $(pwd):/xttcpp/ -d -t --name xttcpp xaptumeng/xtt-cpp-build:0.1.2
   - docker exec -it xttcpp bash -c "cd xttcpp && mkdir -p build"
   - docker exec -it xttcpp bash -c "cd xttcpp/build && cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_CXX_COMPILER=${CXX_COMPILER}"
   - docker exec -it xttcpp bash -c "cd xttcpp/build && make"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ if(NOT DEFINED BUILD_SHARED_LIBS OR NOT  "${BUILD_SHARED_LIBS}")
 endif()
 
 find_package(Threads REQUIRED QUIET)
-find_package(Boost 1.66 COMPONENTS system thread REQUIRED QUIET)
+find_package(Boost 1.70 COMPONENTS system thread REQUIRED QUIET)
 
 find_package(xtt 0.10.2 REQUIRED QUIET)
 

--- a/asio/include/xtt/asio/server_context.hpp
+++ b/asio/include/xtt/asio/server_context.hpp
@@ -24,10 +24,10 @@
 
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/io_context.hpp>
-#include <boost/asio/io_context_strand.hpp>
 #include <boost/asio/bind_executor.hpp>
 #include <boost/asio/write.hpp>
 #include <boost/asio/read.hpp>
+#include <boost/asio/strand.hpp>
 #include <boost/system/error_code.hpp>
 
 #include <memory>
@@ -169,7 +169,7 @@ namespace asio {
         server_handshake_context handshake_ctx_;
 
         boost::asio::ip::tcp::socket socket_;
-        boost::asio::io_context::strand strand_;
+        boost::asio::strand<boost::asio::executor> strand_;
 
         xtt::identity requested_client_id_;
         xtt::group_identity claimed_group_id_;
@@ -186,4 +186,3 @@ namespace asio {
 #include "server_context.inl"
 
 #endif
-

--- a/asio/src/server_context.cpp
+++ b/asio/src/server_context.cpp
@@ -28,7 +28,7 @@ server_context::server_context(boost::asio::ip::tcp::socket tcp_socket,
       io_buf_(),
       handshake_ctx_(in_buffer_.data(), in_buffer_.size(), out_buffer_.data(), out_buffer_.size()),
       socket_(std::move(tcp_socket)),
-      strand_(socket_.get_io_service()),
+      strand_(boost::asio::make_strand(socket_.lowest_layer().get_executor())),
       cert_map_(),
       cert_(cert_map_.end()),
       cookie_ctx_(cookie_ctx)


### PR DESCRIPTION
The ASIO `executor.get_io_context()` dprecated APIs were removed in
Boost 1.70.  This commit updates our code to use the new
executor-based APIs and sets the minimum Boost version 1.70.

This upgrade is necessary to build with the latest compilers on OSX.
Boost 1.66 (the prior version) does not compile on the latest Clang.